### PR TITLE
updates based on outstanding PR

### DIFF
--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -1,25 +1,27 @@
 <template>
 
-  <card-grid :header="title" v-if="slicedContents.length">
-    <content-card
-      v-for="content in slicedContents"
-      :title="content.title"
-      :thumbnail="content.thumbnail"
-      :kind="content.kind"
-      :progress="content.progress"
-      :id="content.id">
-    </content-card>
-  </card-grid>
+  <div>
+    <card-grid :header="title" v-if="slicedContents.length">
+      <content-card
+        v-for="content in slicedContents"
+        :title="content.title"
+        :thumbnail="content.thumbnail"
+        :kind="content.kind"
+        :progress="content.progress"
+        :id="content.id">
+      </content-card>
+    </card-grid>
 
-  <div class='button-wrapper' v-if="contents.length > nCollapsed">
-    <button class='disclosure-button' @click='toggle()' v-if='expanded'>
-      <svg src="show-less.svg"></svg>
-      Show Less
-    </button>
-    <button class='disclosure-button' @click='toggle()' v-else>
-      <svg src="show-more.svg"></svg>
-      Show More
-    </button>
+    <div class='button-wrapper' v-if="contents.length > nCollapsed">
+      <button class='disclosure-button' @click='toggle()' v-if='expanded'>
+        <svg src="show-less.svg"></svg>
+        Show Less
+      </button>
+      <button class='disclosure-button' @click='toggle()' v-else>
+        <svg src="show-more.svg"></svg>
+        Show More
+      </button>
+    </div>
   </div>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/expandable-content-grid/index.vue
@@ -79,10 +79,6 @@
 
   .button-wrapper
     text-align: center
-    position: absolute
-    left: 50%
-    transform: translateX(-50%)
-    padding-bottom: 60px
 
   .disclosure-button
     padding-right: 1em // visually compensate for icon padding on left

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -98,7 +98,7 @@
     padding-left: $left-margin
     padding-right: $right-margin
     padding-bottom: 50px
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       padding-left: $left-margin - 20px
 
   .search-btn

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -118,6 +118,9 @@
     height: 100%
     width: 100%
     padding-left: $left-margin
+    @media screen and (max-width: $portrait-breakpoint)
+      padding-left: 0
+      margin-left: $card-gutter
 
   .search-shadow
     padding-right: $right-margin

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -99,7 +99,8 @@
     padding-right: $right-margin
     padding-bottom: 50px
     @media screen and (max-width: $portrait-breakpoint)
-      padding-left: $left-margin - 20px
+      padding-left: $card-gutter * 2
+      padding-right: $card-gutter
 
   .search-btn
     position: fixed

--- a/kolibri/plugins/learn/assets/src/vue/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/index.vue
@@ -101,6 +101,7 @@
     @media screen and (max-width: $portrait-breakpoint)
       padding-left: $card-gutter * 2
       padding-right: $card-gutter
+      padding-bottom: 100px
 
   .search-btn
     position: fixed
@@ -131,6 +132,7 @@
 
   .page-content
     margin: auto
+    padding-right: $card-gutter // visible right-margin in line with grid
     width-auto-adjust()
 
 </style>

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -15,7 +15,7 @@ $right-margin = 55px
 grid-width($n-cols)
   ($card-width * $n-cols) + ($card-gutter * $n-cols)
 
-$portrait-breakpoint = $left-margin + grid-width(1) + $right-margin
+$portrait-breakpoint = $left-margin * 2 + grid-width(1) + $right-margin
 
 // compute the media query breakpoint, based on the target grid width
 breakpoint($width)

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -18,6 +18,8 @@ $right-margin = 55
 grid-width($n-cols)
   ($card-width * $n-cols) + ($card-gutter * $n-cols)
 
+$portrait-breakpoint = $left-margin + grid-width(1) + $right-margin
+
 // compute the media query breakpoint, based on the target grid width
 breakpoint($width)
   $left-margin + $width + $card-gutter + $right-margin

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -8,11 +8,10 @@ $card-width = 280px         // fixed card width
 $card-gutter = 20px         // spacing between columns
 $n-cols-array = 1 2 3 4 5     // possible numbers of columns
 
-
 $nav-bar-width = 80px       // width of side-nav
 
 $left-margin = 80px
-$right-margin = 55
+$right-margin = 55px
 
 // compute the target grid width based on the number of columns
 grid-width($n-cols)

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -24,7 +24,7 @@ breakpoint($width)
 
 // generate a range of media query breakpoints
 width-auto-adjust()
-  min-width: $card-width
+  width: grid-width(1)
   for $n-cols in $n-cols-array
     $grid-width = grid-width($n-cols)
     @media (min-width: breakpoint($grid-width))

--- a/kolibri/plugins/learn/assets/src/vue/learn.styl
+++ b/kolibri/plugins/learn/assets/src/vue/learn.styl
@@ -8,8 +8,6 @@ $card-width = 280px         // fixed card width
 $card-gutter = 20px         // spacing between columns
 $n-cols-array = 1 2 3 4 5     // possible numbers of columns
 
-$nav-bar-width = 80px       // width of side-nav
-
 $left-margin = 80px
 $right-margin = 55px
 

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/index.vue
@@ -137,6 +137,8 @@
 
   .results
     padding-top: $top-offset
+    @media screen and (max-width: $portrait-breakpoint)
+      margin-left: $card-gutter
 
   .top
     background-color: $core-bg-canvas
@@ -147,6 +149,9 @@
     position: fixed
     top: 0
     width-auto-adjust()
+    @media screen and (max-width: $portrait-breakpoint)
+      text-align: left
+      padding-right: 10px
 
   input
     display: inline-block

--- a/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
+++ b/kolibri/plugins/learn/assets/src/vue/search-widget/search-button.vue
@@ -33,6 +33,7 @@
     border: none
     height: 36px
     width: 36px
+    background-color: $core-bg-canvas
 
     svg
       fill: $core-action-normal

--- a/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
@@ -78,25 +78,25 @@
     overflow: hidden
     position: fixed
     z-index: 2
-    @media screen and (orientation: landscape)
+    @media screen and (min-width: $portrait-breakpoint)
       height: 100%
       top: 0
       left: 0
       width: $left-margin - $card-gutter * 0.5
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       bottom: 0
       width: 100%
       height: auto
       display: table
       font-size: 10px
-      
+
   .nav-row
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       display: table-row
 
   .nav-spacer
     height: 0
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       height: 40px
 
   a
@@ -106,14 +106,14 @@
     display: block
     margin: 0
     padding: 0
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       display: table-cell
       height: auto
       padding-bottom: 4px
 
   .content
     align(vertical)
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       left: 50%
       transform: translateX(-50%)
       width: 50px
@@ -126,7 +126,7 @@
   svg
     fill: $core-action-normal
     transition: fill $core-time ease-out
-    @media screen and (orientation: portrait)
+    @media screen and (max-width: $portrait-breakpoint)
       height: 30px
       margin-bottom: -2px
       margin-top: 2px

--- a/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
@@ -1,20 +1,18 @@
 <template>
 
   <nav role="navigation" aria-label="Main user navigation">
-    <div class="nav-row">
-      <a v-link="learnLink" @click='closeSearch' :class="learnClass">
-        <div class='content'>
-          <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/learn.svg"></svg>
-          Learn
-        </div>
-      </a>
-      <a v-link="exploreLink" @click='closeSearch' :class="exploreClass">
-        <div class='content'>
-          <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
-          Explore
-        </div>
-      </a>
-    </div>
+    <a v-link="learnLink" @click='closeSearch' :class="learnClass">
+      <div class='content'>
+        <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/learn.svg"></svg>
+        <label>Learn</label>
+      </div>
+    </a>
+    <a v-link="exploreLink" @click='closeSearch' :class="exploreClass">
+      <div class='content'>
+        <svg role="presentation" height="40" width="40" viewbox="0 0 24 24" src="../icons/explore.svg"></svg>
+        <label>Explore</label>
+      </div>
+    </a>
   </nav>
 
 </template>
@@ -68,68 +66,58 @@
   @require '../learn'
   @require 'jeet'
 
-  $nav-element-height = 150px
   $font-size = 1em
+  $nav-size = $left-margin - $card-gutter * 0.5
+  $portrait-scale = 0.8
 
   nav
     background: $core-bg-light
-    font-size: $font-size
     font-weight: 300
     overflow: hidden
     position: fixed
     z-index: 2
     @media screen and (min-width: $portrait-breakpoint + 1)
+      font-size: 1em
       height: 100%
       top: 0
       left: 0
-      width: $left-margin - $card-gutter * 0.5
+      width: $nav-size px
     @media screen and (max-width: $portrait-breakpoint)
+      font-size: $font-size * $portrait-scale
+      height: $nav-size * $portrait-scale px
       bottom: 0
       width: 100%
-      height: auto
-      display: table
-      font-size: 10px
-
-  .nav-row
-    @media screen and (max-width: $portrait-breakpoint)
-      display: table-row
-
-  .nav-spacer
-    height: 0
-    @media screen and (max-width: $portrait-breakpoint)
-      height: 40px
-
-  a
-    text-align: center
-    position: relative
-    height: $nav-element-height
-    display: block
-    margin: 0
-    padding: 0
-    @media screen and (max-width: $portrait-breakpoint)
-      display: table-cell
-      height: auto
-      padding-bottom: 4px
 
   .content
-    align(vertical)
+    align(all)
+
+  a
+    margin: 0
+    padding: 0
+    position: relative
+    @media screen and (min-width: $portrait-breakpoint + 1)
+      height: 150px
+      display: block
     @media screen and (max-width: $portrait-breakpoint)
-      left: 50%
-      transform: translateX(-50%)
-      width: 50px
-      position: relative
+      height: 100%
+      column(1/2)
+      padding-bottom: 4px
 
   a.active
     color: $core-bg-light
     background: $core-action-normal
 
+  label
+    display: block
+    text-align: center
+
   svg
+    display: block
+    margin: auto
     fill: $core-action-normal
     transition: fill $core-time ease-out
     @media screen and (max-width: $portrait-breakpoint)
       height: 30px
-      margin-bottom: -2px
-      margin-top: 2px
 
   a:hover svg
     fill: $core-action-dark

--- a/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
+++ b/kolibri/plugins/learn/assets/src/vue/side-nav/index.vue
@@ -78,7 +78,7 @@
     overflow: hidden
     position: fixed
     z-index: 2
-    @media screen and (min-width: $portrait-breakpoint)
+    @media screen and (min-width: $portrait-breakpoint + 1)
       height: 100%
       top: 0
       left: 0


### PR DESCRIPTION
see comments on https://github.com/learningequality/kolibri/pull/303
- fixes up alignment
- remove `position: absolute` from 'show more' button
- adds a wrapper div to `<expandable-content-grid>`
- changes media queries from `portrait` to a standard width based on card size
- migrates nav from `table` to jeet's `col`
- adds a background color to search button to help with overlapping content
- improves search pane behavior
