### PR TITLE
Make save not require payload information if the model is not synced.

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -113,7 +113,8 @@ class Model {
             }
           });
         } else {
-          payload = attrs;
+          this.set(attrs);
+          payload = this.attributes;
         }
         if (!Object.keys(payload).length) {
           // Nothing to save, so just resolve the promise now.

--- a/kolibri/plugins/setup_wizard/assets/src/actions.js
+++ b/kolibri/plugins/setup_wizard/assets/src/actions.js
@@ -5,9 +5,9 @@ const FacilityResource = Kolibri.resources.FacilityResource;
 
 function createDeviceOwnerAndFacility(store, deviceownerpayload, facilitypayload) {
   const DeviceOwnerModel = DeviceOwnerResource.createModel(deviceownerpayload);
-  const deviceOwnerPromise = DeviceOwnerModel.save(deviceownerpayload);
+  const deviceOwnerPromise = DeviceOwnerModel.save();
   const FacilityModel = FacilityResource.createModel(facilitypayload);
-  const facilityPromise = FacilityModel.save(facilitypayload);
+  const facilityPromise = FacilityModel.save();
   const promises = [deviceOwnerPromise, facilityPromise];
   Promise.all(promises).then(responses => {
     // redirect to learn page after successfully created the DeviceOwner and Facility.


### PR DESCRIPTION
Fixes https://github.com/learningequality/kolibri/pull/332#discussion_r73794854.
